### PR TITLE
Implement a fall-back version of the property pool for previous deal.II versions

### DIFF
--- a/include/aspect/particle/property_pool.h
+++ b/include/aspect/particle/property_pool.h
@@ -43,7 +43,13 @@ namespace aspect
     class PropertyPool
     {
       public:
+#if DEAL_II_VERSION_GTE(8,5,0)
         typedef IndexSet::size_type Handle;
+#else
+        typedef double *Handle;
+#endif
+        static const Handle invalid_handle;
+
 
         PropertyPool (const unsigned int n_properties_per_slot);
 
@@ -59,14 +65,16 @@ namespace aspect
          * Reserves the dynamic memory needed for storing the properties of
          * @p size particles.
          */
-        void reserve(const unsigned int size);
+        void reserve(const std::size_t size);
 
       private:
         unsigned int n_properties;
 
+#if DEAL_II_VERSION_GTE(8,5,0)
         std::vector<double> memory_pool;    // size == n_slots * n_properties_per_slot;
         std::vector<std::vector<double>::size_type> translation_table; // size = n_slots, content: Addresses within memory_pool
         IndexSet free_slots; // size = number_of_slots, n_elements = currently free slots
+#endif
     };
 
   }

--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -31,7 +31,7 @@ namespace aspect
       reference_location(),
       id (0),
       property_pool(NULL),
-      properties(numbers::invalid_unsigned_int)
+      properties(PropertyPool::invalid_handle)
     {
     }
 
@@ -45,7 +45,7 @@ namespace aspect
       reference_location (new_reference_location),
       id (new_id),
       property_pool(NULL),
-      properties (numbers::invalid_unsigned_int)
+      properties (PropertyPool::invalid_handle)
     {
     }
 
@@ -56,7 +56,7 @@ namespace aspect
       reference_location (particle.get_reference_location()),
       id (particle.get_id()),
       property_pool(particle.property_pool),
-      properties ((property_pool != NULL) ? property_pool->allocate_properties_array() : numbers::invalid_unsigned_int)
+      properties ((property_pool != NULL) ? property_pool->allocate_properties_array() : PropertyPool::invalid_handle)
     {
       if (property_pool != NULL)
         {
@@ -107,7 +107,7 @@ namespace aspect
       property_pool(particle.property_pool),
       properties(particle.properties)
     {
-      particle.properties = numbers::invalid_unsigned_int;
+      particle.properties = PropertyPool::invalid_handle;
     }
 
     template <int dim>
@@ -133,7 +133,7 @@ namespace aspect
                 }
             }
           else
-            properties = numbers::invalid_unsigned_int;
+            properties = PropertyPool::invalid_handle;
         }
       return *this;
     }
@@ -149,7 +149,7 @@ namespace aspect
           id = particle.id;
           property_pool = particle.property_pool;
           properties = particle.properties;
-          particle.properties = numbers::invalid_unsigned_int;
+          particle.properties = PropertyPool::invalid_handle;
         }
       return *this;
     }
@@ -158,7 +158,7 @@ namespace aspect
     template <int dim>
     Particle<dim>::~Particle ()
     {
-      if (properties != numbers::invalid_unsigned_int)
+      if (properties != PropertyPool::invalid_handle)
         property_pool->deallocate_properties_array(properties);
     }
 
@@ -233,7 +233,7 @@ namespace aspect
     void
     Particle<dim>::set_properties (const std::vector<double> &new_properties)
     {
-      if (properties == numbers::invalid_unsigned_int)
+      if (properties == PropertyPool::invalid_handle)
         properties = property_pool->allocate_properties_array();
 
       const ArrayView<double> old_properties = property_pool->get_properties(properties);


### PR DESCRIPTION
It compiles, and it seems to work on the property tests to the degree that I can check that (small differences in output, but no segfaults etc.) except for the case you've also already found where the copy constructor of `ArrayView` falls over its own feet.

This also fixes the mismatched types in declaration and definition of the `reserve()` function -- the declaration and definition had different types, and both were wrong ;-)