### PR TITLE
Avoid querying properties if there are no properties

### DIFF
--- a/include/aspect/particle/property_pool.h
+++ b/include/aspect/particle/property_pool.h
@@ -67,6 +67,8 @@ namespace aspect
          */
         void reserve(const std::size_t size);
 
+        unsigned int n_properties_per_slot () const;
+
       private:
         unsigned int n_properties;
 

--- a/source/particle/output/ascii.cc
+++ b/source/particle/output/ascii.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2015 by the authors of the ASPECT code.
+  Copyright (C) 2015, 2016 by the authors of the ASPECT code.
 
  This file is part of ASPECT.
 
@@ -91,12 +91,15 @@ namespace aspect
         // And print the data for each particle
         for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator it=particles.begin(); it!=particles.end(); ++it)
           {
-            const ArrayView<const double> properties = it->second.get_properties();
 
             output << it->second.get_location();
             output << ' ' << it->second.get_id();
-            for (unsigned int i = 0; i < properties.size(); ++i)
-              output << ' ' << properties[i];
+            if (property_information.n_components() > 0)
+              {
+                const ArrayView<const double> properties = it->second.get_properties();
+                for (unsigned int i = 0; i < properties.size(); ++i)
+                  output << ' ' << properties[i];
+              }
 
             output << "\n";
           }

--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2015 by the authors of the ASPECT code.
+  Copyright (C) 2015, 2016 by the authors of the ASPECT code.
 
  This file is part of ASPECT.
 
@@ -58,15 +58,16 @@ namespace aspect
       property_pool(particle.property_pool),
       properties ((property_pool != NULL) ? property_pool->allocate_properties_array() : PropertyPool::invalid_handle)
     {
-      if (property_pool != NULL)
+      // copy properties as necessary
+      if ((property_pool != NULL)
+          &&
+          (property_pool->n_properties_per_slot() > 0))
         {
           const ArrayView<const double> their_properties = particle.get_properties();
-
-          if (their_properties.size() != 0)
-            {
-              const ArrayView<double> my_properties = property_pool->get_properties(properties);
-              std::copy(&their_properties[0],&their_properties[0]+their_properties.size(),&my_properties[0]);
-            }
+          const ArrayView<double>       my_properties    = property_pool->get_properties(properties);
+          std::copy(&their_properties[0],
+                    &their_properties[0]+their_properties.size(),
+                    &my_properties[0]);
         }
     }
 

--- a/source/particle/property_pool.cc
+++ b/source/particle/property_pool.cc
@@ -106,6 +106,14 @@ namespace aspect
     }
 
 
+    unsigned int
+    PropertyPool::n_properties_per_slot () const
+    {
+      return n_properties;
+    }
+
+
+
     void
     PropertyPool::reserve(const std::size_t size)
     {


### PR DESCRIPTION
This avoids the awkward issue of the broken `ArrayView` class in deal.II 8.4.1 and before.